### PR TITLE
Fix share squares

### DIFF
--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -65,8 +65,8 @@ const PREFERRED_RESULTS = [
 
 export const RESULT_EMOJI: { [result in LetterResult]: string } = {
   [LetterResult.Correct]: '🟩',
-  [LetterResult.Empty]: '⬜️',
-  [LetterResult.Incorrect]: '⬜️',
+  [LetterResult.Empty]: '⬜',
+  [LetterResult.Incorrect]: '⬜',
   [LetterResult.Present]: '🟨',
 };
 


### PR DESCRIPTION
The share thing looks a bit wonky when pasted on discord, while the original wordle looks fine. I copied the symbols from the share text on the original one and apparently the grey ones are slightly different. Not super sure of what's going on here, but here it is.

Here's how sqwordle looks when pasted on discord:

![wonky](https://user-images.githubusercontent.com/111554/149073781-a998ffb5-f21d-4a29-a0a5-fc54c0d700f9.png)

versus using the symbols of wordle:

![wordle](https://user-images.githubusercontent.com/111554/149073845-09b41f9a-333f-4160-b30c-be0c6a7861c5.png)
